### PR TITLE
adjusting for correctly cloning the aws-fpga.git clone, at the start …

### DIFF
--- a/modules/module_01/README.md
+++ b/modules/module_01/README.md
@@ -7,13 +7,13 @@ Before starting this module, perform a fresh reinstall of the AWS EC2 FPGA Devel
 
 ```bash  
 # Install the AWS EC2 FPGA Development Kit
-cd $AWS_FPGA_REPO_DIR
+export LAB_WORK_DIR=/home/centos/src/project_data/
+cd $LAB_WORK_DIR
 git clone https://github.com/aws/aws-fpga.git  
 cd $AWS_FPGA_REPO_DIR                                     
 source vitis_setup.sh
 
 # Download the Vitis F1 Developer Labs
-export LAB_WORK_DIR=/home/centos/src/project_data/
 cd $LAB_WORK_DIR
 rm -rf Vitis-AWS-F1-Developer-Labs
 git clone https://github.com/Xilinx/Vitis-AWS-F1-Developer-Labs.git Vitis-AWS-F1-Developer-Labs


### PR DESCRIPTION
…this repo doesnt exists so AWS_FPGA_REPO_DIR points to no existant dir